### PR TITLE
Added interface to GLQP

### DIFF
--- a/src/spxmod/regmod_builder.py
+++ b/src/spxmod/regmod_builder.py
@@ -25,6 +25,47 @@ from spxmod.linalg import get_pred_var
 from spxmod.typing import Callable, DataFrame, NDArray, RegmodModel, Series
 
 
+def glqp_optimize(
+    model: RegmodModel, x0: NDArray | None = None, verbose = True
+) -> NDArray:
+    from glqp import LogisticNLL,PoissonNLL,GaussianNLL
+    from glqp import GLQP
+    #Import inside so no error if not installed and calling msca_optimize
+    zero_vec = np.zeros(model.size)
+    b = -1. * model.gradent_from_gprior(zero_vec)
+    A = model.mat[0]
+    Q = model.hessian_from_gprior
+    y = model.data.obs
+    w = model.data.weights
+    b = -model.gradient_from_gprior(np.zeros(model.size))
+
+    if model.cmat.size == 0:
+        C = None
+        c = None
+    else:
+        C = model.cmat
+        c = model.cvec,
+
+    if type(model)==SparseBinomialModel:
+        glm_f = LogisticNLL(y,w)
+    elif type(model)==SparseGaussianModel:
+        glm_f = GaussianNLL(y,w)
+    elif type(model)==SparsePoissonModel:
+        glm_f = PoissonNLL(y,w)
+    else:
+        raise ValueError("Model not compatible, must be one of SparseBinomialModel,SparseGaussianModel,SparsePoissonModel")
+    glqp_problem = GLQP(
+        f = glm_f, A = A,
+        Q = Q, b = b,
+        C = C,c = c
+        )
+    x,opt_result = glqp_problem.solve(verbose = verbose)
+    model.opt_result = opt_result
+    model.opt_coefs = x.copy()
+    model.opt_hessian = model.hessian(model.opt_coefs)
+    model.opt_jacobian2 = model.jacobian2(model.opt_coefs)
+    return x
+
 def msca_optimize(
     model: RegmodModel, x0: NDArray | None = None, options: dict | None = None
 ) -> NDArray:

--- a/src/spxmod/regmod_builder.py
+++ b/src/spxmod/regmod_builder.py
@@ -44,7 +44,7 @@ def glqp_optimize(
         c = None
     else:
         C = model.cmat
-        c = model.cvec,
+        c = model.cvec
 
     if type(model)==SparseBinomialModel:
         glm_f = LogisticNLL(y,w)

--- a/src/spxmod/regmod_builder.py
+++ b/src/spxmod/regmod_builder.py
@@ -60,7 +60,7 @@ def glqp_optimize(
         C = C,c = c
         )
     x,opt_result = glqp_problem.solve(verbose = verbose)
-    if 'optimal' in opt_result.termination_tag:
+    if 'opt' in opt_result.termination_tag:
         opt_result.success = True
     else:
         opt_result.success = False

--- a/src/spxmod/regmod_builder.py
+++ b/src/spxmod/regmod_builder.py
@@ -28,11 +28,11 @@ from spxmod.typing import Callable, DataFrame, NDArray, RegmodModel, Series
 def glqp_optimize(
     model: RegmodModel, x0: NDArray | None = None, verbose = True
 ) -> NDArray:
-    from glqp import LogisticNLL,PoissonNLL,GaussianNLL
+    from glqp.obj import LogisticNLL,PoissonNLL,GaussianNLL
     from glqp import GLQP
     #Import inside so no error if not installed and calling msca_optimize
     zero_vec = np.zeros(model.size)
-    b = -1. * model.gradent_from_gprior(zero_vec)
+    b = -1. * model.gradient_from_gprior(zero_vec)
     A = model.mat[0]
     Q = model.hessian_from_gprior
     y = model.data.obs

--- a/src/spxmod/regmod_builder.py
+++ b/src/spxmod/regmod_builder.py
@@ -60,6 +60,10 @@ def glqp_optimize(
         C = C,c = c
         )
     x,opt_result = glqp_problem.solve(verbose = verbose)
+    if 'optimal' in opt_result.termination_tag:
+        opt_result.success = True
+    else:
+        opt_result.success = False
     model.opt_result = opt_result
     model.opt_coefs = x.copy()
     model.opt_hessian = model.hessian(model.opt_coefs)


### PR DESCRIPTION
New optimizer can be called with:
```
import numpy as np
import pandas as pd
import yaml
from spxmod.model import XModel
import matplotlib.pyplot as plt
# environment: /mnt/team/msca/priv/jira/MSCA-399-rover-stage/env
from spxmod.regmod_builder import glqp_optimize

with open("xmodel_config.yaml", "r") as f:
    xmodel_config = yaml.safe_load(f)

data = pd.read_parquet("data.parquet").query("train")
train = data.query("~holdout").reset_index(drop=True)
test = data.query("holdout").reset_index(drop=True)

xmodel = XModel.from_config(xmodel_config["xmodel"])
xmodel.fit(train, data_span=data, optimizer = glqp_optimize)
```
