### PR TITLE
No repeat building core config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
 
     setup(
         name="spxmod",
-        version="0.3.1",
+        version="0.3.2",
         description="Coefficient-smoothing regression models",
         long_description=long_description,
         license="LICENSE",

--- a/src/spxmod/model.py
+++ b/src/spxmod/model.py
@@ -112,6 +112,7 @@ class XModel:
         self.spaces = spaces
         self.var_builders = var_builders
 
+        self.core_config_set = False
         self.core: RegmodModel | None = None
 
     @classmethod
@@ -130,12 +131,18 @@ class XModel:
         return cls(**config)
 
     def _set_core_config(self, data: DataFrame) -> None:
-        for space in self.spaces:
-            space.set_span(data)
+        if not self.core_config_set:
+            for space in self.spaces:
+                space.set_span(data)
 
-        self.core_config["variables"] = self._build_variables()
-        self.core_config["linear_gpriors"].extend(self._build_linear_gpriors())
-        self.core_config["linear_upriors"].extend(self._build_linear_upriors())
+            self.core_config["variables"] = self._build_variables()
+            self.core_config["linear_gpriors"].extend(
+                self._build_linear_gpriors()
+            )
+            self.core_config["linear_upriors"].extend(
+                self._build_linear_upriors()
+            )
+            self.core_config_set = True
 
     def _build_variables(self) -> list[dict]:
         variables = []


### PR DESCRIPTION
## Description

@kels271828 found out an issue if running spxmod multiple times it will produce different results.
https://jira.ihme.washington.edu/browse/MSCA-578

After investigation, we found out that every time we build core config, we will append additional `linear_gprior` and `linear_uprior` to the prior list.

We add an attribute `core_config_set` to track if `core_config` has been built and avoid building it repeatedly.

@kels271828 Take a look when you have a chance and let me know if there are any issues!